### PR TITLE
examples/rtlsdr_rds: Fix tuner filter bandwidth

### DIFF
--- a/examples/rtlsdr_rds.lua
+++ b/examples/rtlsdr_rds.lua
@@ -10,7 +10,7 @@ local tune_offset = -250e3
 
 -- Blocks
 local source = radio.RtlSdrSource(frequency + tune_offset, 1102500, {freq_correction = 1.0})
-local tuner = radio.TunerBlock(tune_offset, 200e6, 5)
+local tuner = radio.TunerBlock(tune_offset, 200e3, 5)
 local fm_demod = radio.FrequencyDiscriminatorBlock(1.25)
 local hilbert = radio.HilbertTransformBlock(129)
 local mixer_delay = radio.DelayBlock(129)


### PR DESCRIPTION
The RDS example wasn't working very well, and I noticed that the noise
floor on the "Demodulated FM Spectrum" plot was much higher in the RDS
example than in the WBFM stereo example, so I compared the two, and
found the difference in this value.

A filter with a 200MHz passband isn't going to do much, and after fixing
it, I'm getting better results with RDS.