### PR TITLE
Add installation infos for Mac OS X with Homebrew

### DIFF
--- a/docs/1.installation.md
+++ b/docs/1.installation.md
@@ -16,6 +16,18 @@ LuaRadio is available in the Arch Linux AUR under the package
 
 Desktop users should also install the `gnuplot` package for plotting support.
 
+## Installing on Mac OS X with Homebrew
+
+To install LuaRadio on Mac OS X, you can use [Homebrew](http://brew.sh/):
+
+```
+brew install luaradio
+```
+
+*Note*: Currently the optional dependency liquid-dsp is not available, yet.
+Alternatively the package `gnuradio` can be installed (`brew install gnuradio`)
+additionally to make VOLK available.
+
 ## Installing from Source
 
 ### Install prerequisites


### PR DESCRIPTION
As Homebrew/homebrew-core#2665 is merged LuaRadio can now be installed with Homebrew on Mac OS X. This commit adds a short description on how to do that.