### PR TITLE
Fix typo in docs example for GnuplotSpectrumSink

### DIFF
--- a/radio/blocks/sinks/gnuplotspectrum.lua
+++ b/radio/blocks/sinks/gnuplotspectrum.lua
@@ -26,7 +26,7 @@
 --
 -- @usage
 -- -- Plot the spectrum of a 1 kHz complex exponential sampled at 250 kHz
--- local snk = radio.SignalSource('exponential', 1e3, 250e3)
+-- local src = radio.SignalSource('exponential', 1e3, 250e3)
 -- local throttle = radio.ThrottleBlock()
 -- local snk = radio.GnuplotSpectrumSink()
 -- top:connect(src, throttle, snk)


### PR DESCRIPTION
The example for GnuplotSpectrumSink has two `snk`s defined, rather than a `src` and a `snk`. This fixes it.