### PR TITLE
Fixed 'Symbol not found: __Z10getEnvImplPKc' on MacOS with SoapySDR.

### DIFF
--- a/radio/blocks/sinks/soapysdr.lua
+++ b/radio/blocks/sinks/soapysdr.lua
@@ -157,7 +157,7 @@ if not package.loaded['radio.blocks.sources.soapysdr'] then
         int SoapySDRDevice_readStreamStatus(SoapySDRDevice *device, SoapySDRStream *stream, size_t *chanMask, int *flags, long long *timeNs, const long timeoutUs);
     ]]
 end
-local libsoapysdr_available, libsoapysdr = pcall(ffi.load, "libSoapySDR")
+local libsoapysdr_available, libsoapysdr = pcall(ffi.load, "libSoapySDR", true)
 
 function SoapySDRSink:initialize()
     -- Check library is available

--- a/radio/blocks/sources/soapysdr.lua
+++ b/radio/blocks/sources/soapysdr.lua
@@ -171,7 +171,7 @@ if not package.loaded['radio.blocks.sinks.soapysdr'] then
         int SoapySDRDevice_readStreamStatus(SoapySDRDevice *device, SoapySDRStream *stream, size_t *chanMask, int *flags, long long *timeNs, const long timeoutUs);
     ]]
 end
-local libsoapysdr_available, libsoapysdr = pcall(ffi.load, "libSoapySDR")
+local libsoapysdr_available, libsoapysdr = pcall(ffi.load, "libSoapySDR", true)
 
 function SoapySDRSource:initialize()
     -- Check library is available


### PR DESCRIPTION
Addresses #44.