### PR TITLE
blocks/sources/rtlsdr: Added bias tee and bandwidth control

### DIFF
--- a/radio/blocks/sources/rtlsdr.lua
+++ b/radio/blocks/sources/rtlsdr.lua
@@ -7,6 +7,8 @@
 -- @tparam number frequency Tuning frequency in Hz
 -- @tparam number rate Sample rate in Hz
 -- @tparam[opt={}] table options Additional options, specifying:
+--                         * `biastee_on` (bool, default false)
+--                         * `bandwidth` (number, default is equal to sample rate)
 --                         * `autogain` (bool, default false)
 --                         * `rf_gain` (number, default closest supported to 10.0 dB)
 --                         * `freq_correction` PPM (number, default 0.0)
@@ -39,6 +41,8 @@ function RtlSdrSource:instantiate(frequency, rate, options)
     self.rate = assert(rate, "Missing argument #2 (rate)")
 
     self.options = options or {}
+    self.biastee_on = self.options.biastee_on or false
+    self.bandwidth = self.options.bandwidth or 0.0  -- 0.0 forces bandwidth=rate. See rtlsdr_set_tuner_bandwidth() implementation
     self.autogain = self.options.autogain or false
     self.rf_gain = self.options.rf_gain or nil
     self.freq_correction = self.options.freq_correction or 0.0
@@ -65,6 +69,8 @@ ffi.cdef[[
     int rtlsdr_set_tuner_if_gain(rtlsdr_dev_t *dev, int stage, int gain);
     int rtlsdr_set_freq_correction(rtlsdr_dev_t *dev, int ppm);
     int rtlsdr_get_tuner_gains(rtlsdr_dev_t *dev, int *gains);
+    int rtlsdr_set_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw);
+    int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on);
 
     int rtlsdr_reset_buffer(rtlsdr_dev_t *dev);
 
@@ -92,6 +98,15 @@ function RtlSdrSource:initialize_rtlsdr()
         error("rtlsdr_open(): " .. tostring(ret))
     end
 
+	-- Turn on bias tee if required, ignore if not required
+    if self.biastee_on then
+        -- Turn on bias tee
+        ret = librtlsdr.rtlsdr_set_bias_tee(self.dev[0], 1)
+        if ret ~= 0 then
+            error("rtlsdr_set_bias_tee(): " .. tostring(ret))
+        end
+	end
+	
     -- Pick a default gain value if one wasn't specified
     if not self.rf_gain and not self.autogain then
         -- Look up number of supported gains
@@ -169,6 +184,12 @@ function RtlSdrSource:initialize_rtlsdr()
         error("rtlsdr_set_sample_rate(): " .. tostring(ret))
     end
 
+    -- Set bandwidth
+    ret = librtlsdr.rtlsdr_set_tuner_bandwidth(self.dev[0], self.bandwidth)
+    if ret ~= 0 then
+        error("rtlsdr_set_tuner_bandwidth(): " .. tostring(ret))
+    end
+
     -- Reset endpoint buffer
     ret = librtlsdr.rtlsdr_reset_buffer(self.dev[0])
     if ret ~= 0 then
@@ -229,6 +250,15 @@ function RtlSdrSource:run()
     if ret ~= 0 then
         error("rtlsdr_read_async(): " .. tostring(ret))
     end
+
+	-- Turn off bias tee if required, ignore if not required
+    if self.biastee_on then
+        -- Turn off bias tee
+        ret = librtlsdr.rtlsdr_set_bias_tee(self.dev[0], 0)
+        if ret ~= 0 then
+            error("rtlsdr_set_bias_tee(): " .. tostring(ret))
+        end
+	end
 
     -- Close rtlsdr
     ret = librtlsdr.rtlsdr_close(self.dev[0])


### PR DESCRIPTION
Added bias tee support for rtl-sdr v3 dongles. If the biastee_on option
is set to true then the bias tee is switched on at initialisation, and
switched off at exit, otherwise the bias tee is ignored. Requires
rtlsdr_set_bias_tee() in librtlsdr (Aug 2016).

Added support for controlling bandwidth seperately from sample rate
through bandwidth option. If this option is not set then bandwidth
defaults to sample rate (previous behaviour). Requires
rtlsdr_set_tuner_bandwidth() in librtlsdr (May 2015).