### PR TITLE
applications: Fix wavfile sink

### DIFF
--- a/radio/applications/init.lua
+++ b/radio/applications/init.lua
@@ -133,7 +133,7 @@ local outputs = {
     wavfile = {
         factory = function (options)
             return function (num_channels)
-                return radio.WAVFileSink(options[1], channels)
+                return radio.WAVFileSink(options[1], num_channels)
             end
         end,
         args = {"filename"},


### PR DESCRIPTION
The WAVFileSink block always throws due to the channel count not being provided as it was being passed an undefined value.