### PR TITLE
Update installation instructions for Ubuntu

### DIFF
--- a/docs/1.installation.md
+++ b/docs/1.installation.md
@@ -42,7 +42,8 @@ Install LuaJIT 2.0.4 or greater and prerequisites:
 * Arch Linux: `sudo pacman -S luajit`
 * macOS (Homebrew): `brew install luajit pkg-config`
 * macOS (MacPorts): `sudo port install luajit pkg-config`
-* Ubuntu/Debian/Rasbpian: `sudo apt-get install luajit pkg-config`
+* Ubuntu: `sudo apt-get install luajit libluajit-5.1-dev pkg-config`
+* Debian/Rasbpian: `sudo apt-get install luajit pkg-config`
 * Fedora/CentOS: `sudo yum install luajit`
 
 ### Installation


### PR DESCRIPTION
The instructions for installation on Ubuntu did not work without installing an additional package.

After installation here is the platform and version:

```
luaradio --platform
luajit          LuaJIT 2.1.0-beta3
os              Linux
arch            x64
page size       4096
cpu count       8
cpu model       11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
features
    fftw3f      true    fftw-3.3.8-sse2-avx
    volk        true    2.4 (avx512cd_64_mmx_orc)
    liquid      true    1.3.2

luaradio --version
LuaRadio 0.10.0 - Vanya A. Sergeev. https://luaradio.io

```