### PR TITLE
applications: fix an elementary error preventing PortAudio being used

### DIFF
--- a/radio/applications/init.lua
+++ b/radio/applications/init.lua
@@ -125,7 +125,7 @@ local outputs = {
     portaudio = {
         factory = function (options)
             return function (num_channels)
-                return radio.PulseAudioSink(num_channels)
+                return radio.PortAudioSink(num_channels)
             end
         end,
         args = {},


### PR DESCRIPTION
This bug looks to be a simple copy-paste error and originates from the
introduction of the application framework in commit 7023db7.