### PR TITLE
Update readme to use libvolk2-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ marked `true` in the platform information:
 * Arch Linux: `sudo pacman -S liquid-dsp libvolk fftw`
 * macOS (Homebrew): `brew install liquid-dsp fftw`
 * macOS (MacPorts): `sudo port install liquid-dsp volk fftw-3`
-* Ubuntu/Debian/Raspbian: `sudo apt-get install libliquid-dev libvolk1-dev libfftw3-dev`
+* Ubuntu/Debian/Raspbian: `sudo apt-get install libliquid-dev libvolk2-dev libfftw3-dev`
 * Fedora/CentOS: `sudo yum install liquid-dsp fftw`
 
 Try out one of the [examples](examples) with an


### PR DESCRIPTION
Package libvolk1-dev is not available, but is referred to by another package. This may mean that the package is missing, has been obsoleted, or is only available from another source However the following packages replace it libvolk2-dev