### PR TITLE
Minor updates for embed/Makefile supporting cross-compiling with Buildroot

### DIFF
--- a/embed/Makefile
+++ b/embed/Makefile
@@ -115,39 +115,33 @@ install-lmod:
 	install -d $(DESTDIR)$(PREFIX)/share/licenses/luaradio
 	install -m644 ../LICENSE $(DESTDIR)$(PREFIX)/share/licenses/luaradio/LICENSE
 
-ifneq ($(shell uname -s),Darwin)
-.PHONY: install
-install: $(STATIC_LIB) $(SHARED_LIB)
+.PHONY: install install-data install-exec
+install: install-exec install-data
+
+install-data:
+	install -d $(DESTDIR)$(PREFIX)/include
+	install -m644 luaradio.h $(DESTDIR)$(PREFIX)/include/luaradio.h
+	install -d $(DESTDIR)$(PREFIX)/share/licenses/luaradio
+	install -m644 ../LICENSE $(DESTDIR)$(PREFIX)/share/licenses/luaradio/LICENSE
+
+install-exec: $(STATIC_LIB) $(SHARED_LIB)
 	install -d $(DESTDIR)$(PREFIX)/lib
+	install -d $(DESTDIR)$(INSTALL_CMOD)
+ifneq ($(shell uname -s),Darwin)
 	install -m755 $(STATIC_LIB) $(DESTDIR)$(PREFIX)/lib/lib$(LIBNAME).a
 	install -m755 $(SHARED_LIB) $(DESTDIR)$(PREFIX)/lib/lib$(LIBNAME).so.$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
 	ln -sf lib$(LIBNAME).so.$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH) $(DESTDIR)$(PREFIX)/lib/lib$(LIBNAME).so.$(VERSION_MAJOR)
 	ln -sf lib$(LIBNAME).so.$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH) $(DESTDIR)$(PREFIX)/lib/lib$(LIBNAME).so
-	install -d $(DESTDIR)$(PREFIX)/include
-	install -m644 luaradio.h $(DESTDIR)$(PREFIX)/include/luaradio.h
-	install -d $(DESTDIR)$(INSTALL_CMOD)
 	ln -sf $(PREFIX)/lib/lib$(LIBNAME).so.$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH) $(DESTDIR)$(INSTALL_CMOD)/radio.so
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m755 ../luaradio $(DESTDIR)$(PREFIX)/bin/luaradio
-	install -d $(DESTDIR)$(PREFIX)/share/licenses/luaradio
-	install -m644 ../LICENSE $(DESTDIR)$(PREFIX)/share/licenses/luaradio/LICENSE
 else
-# Mac OS X install
-.PHONY: install
-install: $(STATIC_LIB) $(SHARED_LIB)
-	install -d $(DESTDIR)$(PREFIX)/lib
+	# Mac OS X install
 	install -m755 $(STATIC_LIB) $(DESTDIR)$(PREFIX)/lib/lib$(LIBNAME).a
 	install -m755 $(SHARED_LIB) $(DESTDIR)$(PREFIX)/lib/lib$(LIBNAME).$(VERSION_MAJOR).dylib
 	ln -sf lib$(LIBNAME).$(VERSION_MAJOR).dylib $(DESTDIR)$(PREFIX)/lib/lib$(LIBNAME).dylib
-	install -d $(DESTDIR)$(PREFIX)/include
-	install -m644 luaradio.h $(DESTDIR)$(PREFIX)/include/luaradio.h
-	install -d $(DESTDIR)$(INSTALL_CMOD)
 	ln -sf $(PREFIX)/lib/lib$(LIBNAME).$(VERSION_MAJOR).dylib $(DESTDIR)$(INSTALL_CMOD)/radio.so
+endif
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m755 ../luaradio $(DESTDIR)$(PREFIX)/bin/luaradio
-	install -d $(DESTDIR)$(PREFIX)/share/licenses/luaradio
-	install -m644 ../LICENSE $(DESTDIR)$(PREFIX)/share/licenses/luaradio/LICENSE
-endif
 
 .PHONY: clean
 clean:

--- a/embed/Makefile
+++ b/embed/Makefile
@@ -60,15 +60,15 @@ VERSION_MINOR := $(shell cd ../; $(LUAJIT) -e "package.path = './?/init.lua;' ..
 VERSION_PATCH := $(shell cd ../; $(LUAJIT) -e "package.path = './?/init.lua;' .. package.path; print(require('radio').version_info.patch)" 2>/dev/null)
 VERSION_COMMIT := $(shell git describe --abbrev --always --tags --dirty 2>/dev/null || echo "")
 
-CFLAGS = -std=c99 -D_DEFAULT_SOURCE
-CFLAGS += $(shell pkg-config --cflags luajit)
-CFLAGS += -fPIC
-CFLAGS += $(OPT) $(DEBUG) $(INCLUDES)
-CFLAGS += -DVERSION_MAJOR=$(VERSION_MAJOR) -DVERSION_MINOR=$(VERSION_MINOR) -DVERSION_PATCH=$(VERSION_PATCH)
-CFLAGS += -DVERSION_COMMIT=\"$(VERSION_COMMIT)\"
-CFLAGS += -Wall -Wextra -Wcast-align -Wcast-qual -Wimplicit
-CFLAGS += -Wpointer-arith -Wswitch -Wredundant-decls -Wreturn-type
-CFLAGS += -Wshadow -Wunused -Wno-unused-parameter
+override CFLAGS += -std=c99 -D_DEFAULT_SOURCE
+override CFLAGS += $(shell pkg-config --cflags luajit)
+override CFLAGS += -fPIC
+override CFLAGS += $(OPT) $(DEBUG) $(INCLUDES)
+override CFLAGS += -DVERSION_MAJOR=$(VERSION_MAJOR) -DVERSION_MINOR=$(VERSION_MINOR) -DVERSION_PATCH=$(VERSION_PATCH)
+override CFLAGS += -DVERSION_COMMIT=\"$(VERSION_COMMIT)\"
+override CFLAGS += -Wall -Wextra -Wcast-align -Wcast-qual -Wimplicit
+override CFLAGS += -Wpointer-arith -Wswitch -Wredundant-decls -Wreturn-type
+override CFLAGS += -Wshadow -Wunused -Wno-unused-parameter
 
 LIBFLAGS = $(shell pkg-config --libs luajit)
 


### PR DESCRIPTION
I've been playing with your project and have a working package prepared for Buildroot using patches from the commits in this pull request. The first patch allows the build environment to define toolchain-specific `CFLAGS` outside of the Makefile and the second lets me *trivially* install everything to the **staging** rootfs and just the executables to the **target** rootfs.

From https://buildroot.org/downloads/manual/manual.html#_buildroot_quick_start:
>  Compared to staging/, target/ contains only the files and libraries needed to run the selected target applications: the development files (headers, etc.) are not present, the binaries are stripped.