### PR TITLE
File "radio/blocks/sources/uniformrandom.lua" as been modified

### DIFF
--- a/radio/blocks/sources/uniformrandom.lua
+++ b/radio/blocks/sources/uniformrandom.lua
@@ -41,14 +41,14 @@ local random_generator_table = {
         function (a, b)
             a, b = a or -1.0, b or 1.0
             return function ()
-                return types.ComplexFloat32((b-a)*math.random()-b, (b-a)*math.random()-b)
+                return types.ComplexFloat32(a+(b-a)*math.random(), a+(b-a)*math.random())
             end
         end,
     [types.Float32] =
         function (a, b)
             a, b = a or -1.0, b or 1.0
             return function ()
-                return types.Float32((b-a)*math.random()-b)
+                return types.Float32(a+(b-a)*math.random())
             end
         end,
     [types.Byte] =
@@ -85,15 +85,16 @@ function UniformRandomSource:get_rate()
 end
 
 function UniformRandomSource:initialize()
-    if self.seed then
-        math.randomseed(self.seed)
-    end
-
     self.out = self.data_type.vector(self.chunk_size)
 end
 
 function UniformRandomSource:process()
     local out = self.out
+
+    -- seed initialisation
+    -- => done only once for each UniformRandomSource block
+    --    as math.randomseed() returns nil
+    self.seed = self.seed and math.randomseed(self.seed)
 
     for i=0, out.length-1 do
         out.data[i] = self.generator()


### PR DESCRIPTION
Changes are the following:

  Formula for random uniform generation in the range [a,b]
  as been modified
    from:   (b-a)*math.random()-b
    to:     a+(b-a)*math.random()

  The initialisation of the random seed has been moved from
  UniformRandomSource:initialize() to UniformRandomSource:process()
  in order to fix the problem of math.random() generating the same
  sequence in all the processes when the math.randomseed() action
  is done before process forking.